### PR TITLE
Foundation for bidirectional

### DIFF
--- a/zigbee event.lua
+++ b/zigbee event.lua
@@ -5,59 +5,15 @@ Pushes events to resident script via socket.
 
 Tag required objects with the "ZIGBEE" keyword and this script will run whenever one of those objects changes.
 
-Add a "z=<zigbee address from zigbee2mqtt" to the keyword as well, or populate "Local Addresses" below
+Add a "z=<zigbee address from zigbee2mqtt" to the keyword as well
 --]]
 
-logging = true
-zPort = 0xBEEF1
-
--- Define the Zigbee address for each group we want to send
-local addresses = {
-    ["0/56/100"] = "0xa4c1389bf2e3ae50",
-}
-
-server = require('socket').udp()
-
--- Get Zigbee address for the group from local addresses or tags
-function getZigbeeAddress(addr,dst)
-    local local_address = addresses[dst]
-    if local_address then
-        log("Using local address for group "..dst..": "..local_address)
-        return local_address
-    end
-
-    local tags = db:getall("SELECT ot.tag FROM objects AS o JOIN objecttags AS ot ON o.id=ot.object WHERE o.id="..addr.." AND ot.tag like 'z=%'")
-    if tags and #tags > 0 then
-        local zigbee_address = string.split(tags[1]["tag"],"=")[2]
-        if zigbee_address then
-            log("Zigbee address found for group "..dst..": "..zigbee_address)
-            return zigbee_address
-        end
-    end
-    
-    log("No Zigbee address found for group "..group)
-    return nil
-end
-
--- Main event processing
-val = event.getvalue()
-parts = string.split(event.dst, '/')
-net = tonumber(parts[1])
-app = tonumber(parts[2])
-group = tonumber(parts[3])
+local logging = true
+local zPort = 0xBEEF1
+local parts = string.split(event.dst, '/') local net = tonumber(parts[1]) local app = tonumber(parts[2]) local group = tonumber(parts[3])
 ramp = GetCBusRampRate(net, app, group)
 
-zigbee_address = getZigbeeAddress(event.dstraw,event.dst)
-
-if not zigbee_address then
-    log("Keyword triggered but don't have a Zigbee address for "..event.dst.." - please update the table in the ZIGBEE script or add a z= tag to the group")
-    return
-end
-  
 -- Send an event to zigbee2mqtt
-local output = zigbee_address.."/"..val.."/"..ramp
-if logging then 
-    log('Sending '..output)
-end
-
-server:sendto(output, '127.0.0.1', zPort)
+local output = event.dst.."/"..event.getvalue().."/"..ramp
+if logging then log('Sending '..output) end
+require('socket').udp():sendto(output, '127.0.0.1', zPort)

--- a/zigbee resident.lua
+++ b/zigbee resident.lua
@@ -10,54 +10,329 @@ mqtt_broker = '192.168.1.1'
 mqtt_username = ''
 mqtt_password = ''
 mqtt_clientid = 'cbus2zigbee'
+eventName = 'zigbee' -- The name of the ZigBee event script
+local checkChanges = 5 -- Interval in seconds to check for changes to object keywords (set to nil to disable change checks, recommended once configuration is stable)
 
-zPort = 0xBEEF1
+local logging = true
 
-logging = true
+local socketTimeout = 0.1
+local mqttTimeout = 0
 
-mqtt_topic = "zigbee2mqtt"
+local zPort = 0xBEEF1
+local mqttTopic = "zigbee2mqtt/"
+local mqttStatus = 2
+local QoS = 2 -- send exactly once
+local zigbee = {}
+local cbusMessages = {} -- message queue
+local mqttMessages = {} -- message queue
 
--- load mqtt module
-mqtt = require("mosquitto")
+local cudRaw = { -- All possible keywords for ZIGBEE objects, used in CUD function to exclude unrelated keywords for change detection
+  'ZIGBEE', 'z=',
+}
+local cudAll = {} local param for _, param in ipairs(cudRaw) do cudAll[param] = true end cudRaw = nil
 
--- create new mqtt client
-client = mqtt.new(mqtt_clientid)
+local function removeIrrelevant(keywords)
+  local curr = {}
+  for _, k in ipairs(keywords:split(',')) do
+    local parts = k:split('=') if parts[2] ~= nil then parts[1] = parts[1]:trim()..'=' end
+    if cudAll[parts[1]] then table.insert(curr, k) end
+  end
+  return table.concat(curr, ',')
+end
 
-client:will_set(mqtt_clientid..'/status', 'offline', 2, true)
-client:login_set(mqtt_username, mqtt_password)
 
-client.ON_CONNECT = function()
-  log("MQTT connected - ready to send commands to zigbee2mqtt")
-  client:publish(mqtt_clientid..'/status', 'online', 2, true)
+--[[
+Check for presence of the event script
+--]]
+local eventScripts = db:getall("SELECT name FROM scripting WHERE type = 'event'")
+found = false
+for _, s in ipairs(eventScripts) do
+  if s.name:lower() == eventName then found = true eventName = s.name end
+end
+if not found then
+  log('Error: Event-based script \''..eventName..'\' not found. Halting')
+  while true do socket.select(nil, nil, 1) end
+end
+
+
+--[[
+Create new mqtt client and callbacks
+--]]
+local client = require("mosquitto").new(mqttClientId)
+if mqttUsername and mqttUsername ~= '' then client:login_set(mqttUsername, mqttPassword) end
+
+client.ON_CONNECT = function(success)
+  if success then
+    log('Connected to Mosquitto broker')
+    mqttStatus = 1
+  end
 end
 
 client.ON_DISCONNECT = function()
-  log("MQTT disconnected - attempting recovery and client reconnect")
-  -- Handled automatically by loop_start()
+  log("Mosquitto broker disconnected - attempting recovery and client reconnect")
 end
 
-client:connect(mqtt_broker)
--- I understand with loop_start, this will automatically re-connect to mqtt
-client:loop_start()
+client.ON_MESSAGE = function(mid, topic, payload)
+  mqttMessages[#mqttMessages + 1] = { topic=topic, payload=payload } -- Queue the message
+end
 
--- C-Bus events to MQTT local listener
+
+--[[
+C-Bus events to MQTT local listener
+--]]
+pcall(function () server:close() end) -- force close the socket on re-entry due to script error
 server = require('socket').udp()
-server:settimeout(1)
+server:settimeout(socketTimeout)
 server:setsockname('127.0.0.1', zPort)
+
+
+--[[
+Get applicable groups and keywords
+--]]
+local function getGroups(kw)
+  local t
+  local grps = {}
+  for _, t in ipairs(db:getall("SELECT o.address, o.tagcache, o.name FROM objects AS o JOIN objecttags AS ot ON o.id=ot.object WHERE ot.tag='"..kw.."'")) do
+    local alias = knxlib.decodega(t.address)
+    local parts = load("return {"..alias:gsub('/',',').."}")()
+    grps[alias] = { tags = {}, name = t.name, keywords = t.tagcache:gsub(', ',','), net = parts[1], app = parts[2], group = parts[3], channel = parts[4], }
+    if parts[2] == 228 then -- Get the measurement app channel name from the CBus tag map
+      local resp = db:getall('SELECT tag FROM cbus_tag_map WHERE tagtype="S" AND net='..parts[1]..' AND app='..parts[2]..' AND grp='..parts[3]..' AND tagid='..parts[4])
+      if resp ~= nil and resp[1] ~= nil and resp[1]['tag'] ~= nil then grps[alias].name = resp[1]['tag'] else grps[alias].name = alias end
+    end
+    local tags = {}
+    local tg
+    for _, tg in ipairs(grps[alias].keywords:split(',')) do
+      parts = tg:split('=')
+      if parts[2] then tags[parts[1]:trim()] = parts[2]:trim() else tags[parts[1]:trim()] = -1 end
+    end
+    grps[alias].tags = tags
+  end
+  return grps
+end
+
+
+--[[
+Get key/value pairs. Returns a keyword if found in 'allow'. (allow, synonym and special parameters are optional).
+--]]
+local function getKeyValue(alias, tags, _L, synonym, special, allow)
+  if synonym == nil then synonym = {} end
+  if special == nil then special = {} end
+  if allow == nil then allow = {} end
+  local dType = nil
+  for k, t in pairs(tags) do
+    k = k:trim()
+    if t ~= -1 then
+      if special[k] ~= nil then special[k] = true end
+      local v = t:trim()
+      if _L[k] then
+        if type(_L[k]) == 'number' then _L[k] = tonumber(v) if _L[k] == nil then error('Error: Bad numeric value for '..alias..', keyword "'..k..'="') end
+        elseif type(_L[k]) == 'table' then
+          _L[k] = string.split(v, '/')
+          local i, tv for i, tv in ipairs(_L[k]) do _L[k][i] = tv:trim() end
+        else _L[k] = v end
+      end
+    else
+      if synonym[k] then k = synonym[k] end
+      if special[k] ~= nil then special[k] = true end
+      if allow[k] then
+        if dType == nil then dType = k else error('Error: More than one "type" keyword used for '..alias) end
+      end
+    end
+  end
+  return dType
+end
+
+
+--[[
+Create / update / delete ZIGBEE devices
+--]]
+local function cudZig()
+  local grps = getGroups('ZIGBEE')
+  local found = {}
+  local addition = false
+  local modification = false
+  local addCount = 0
+  local modCount = 0
+  local remCount = 0
+  local alias, k, v
+
+  for alias, v in pairs(grps) do
+    found[alias] = true
+    local curr = removeIrrelevant(v.keywords)
+
+    if zigbee[alias] and zigbee[alias].keywords ~= curr then modification = true end
+    if not zigbee[alias] or modification then
+      local _L = {
+        z = '',
+      }
+      getKeyValue(alias, v.tags, _L)
+      if _L.z:find('^0[xX]%x*$') then
+        if not modification then addition = true addCount = addCount + 1 else modCount = modCount + 1 end
+        
+        zigbee[alias] = {name=v.name, address=_L.z, net=v.net, app=v.app, group=v.group, keywords=curr, }
+      else
+        log('Error: Invalid or no z= hexadecimal address specified for ZigBee object '..alias)
+        zigbee[alias] = {name=v.name, net=v.net, app=v.app, group=v.group, keywords=curr, } 
+      end
+    end
+  end
+
+  -- Handle deletions
+  for k, v in pairs(zigbee) do
+    if not found[k] then
+      log('Removing '..k..' ZigBee '..v.name) zigbee[k] = nil remCount = remCount + 1
+    end
+  end
+  if remCount > 0 then
+    log('Removed '..remCount..' ZigBee object'..(remCount ~= 1 and 's' or '')..', event script \''..eventName..'\' restarted')
+  end
+  -- Handle additions/modifications
+  if addition or modification then
+    if addition then log('Added '..addCount..' ZigBee object'..(addCount ~= 1 and 's' or '')..(addCount > 0 and ', event script \''..eventName..'\' restarted' or '')) end
+    if modification then log('Modified '..modCount..' ZigBee object'..(modCount ~= 1 and 's' or '')..(modCount > 0 and ', event script \''..eventName..'\' restarted' or '')) end
+  end
+  if addCount > 0 or modCount > 0 or remCount > 0 then
+    script.disable(eventName) script.enable(eventName) -- Ensure that newly changed keyworded groups send updates
+  end
+end
+
+
+--[[
+Publish to MQTT
+--]]
+function publish(alias, level)
+  local msg = {
+    brightness = level,
+    state = (level ~= 0) and "ON" or "OFF",
+  }
+  client:publish(mqttTopic..zigbee[alias].address..'/set', json.encode(msg), QoS, true)
+end
+
+
+--[[
+Publish current level and state to MQTT
+--]]
+function publishCurrent()
+  local alias, v
+  for alias, v in pairs(zigbee) do
+    publish(alias, grp.getvalue(alias))
+  end
+end
+
+
+--[[
+Receive commands from C-Bus and publish to MQTT
+--]]
+function outstandingCbusMessage()
+  for _, cmd in ipairs(cbusMessages) do
+    parts = string.split(cmd, "/")
+    alias = parts[1]..'/'..parts[2]..'/'..parts[3]
+    local level = tonumber(parts[4])
+    local ramp = tonumber(parts[5]) -- Ignoring ramp for now
+    publish(alias, level)
+  end
+  cbusMessages = {}
+end
+
+
+--[[
+Send commands subscribed from MQTT to C-Bus
+--]]
+function outstandingMqttMessage()
+  for _, cmd in ipairs(mqttMessages) do
+    
+  end
+  mqttMessages = {}
+end
+
+-- Reconnect variables
+local warningTimeout = 30
+local timeout = 1
+local init = true
+local reconnect = false
+local timeoutStart, connectStart, mqttConnected
+
+local changesChecked = socket.gettime()
 
 -- Main loop: process commands
 while true do
+  -- Check for new messages from CBus. The entire socket buffer is collected each iteration for efficiency.
+  local stat, err
+  local more = false
+  stat, err = pcall(function ()
+    ::checkAgain::
+    local cmd = nil
+	  cmd = server:receive()
+    if cmd and type(cmd) == 'string' then
+      cbusMessages[#cbusMessages + 1] = cmd -- Queue the new message
+      server:settimeout(0); more = true; goto checkAgain -- Immediately check for more buffered inbound messages to queue
+    else
+      if more then server:settimeout(socketTimeout) end
+    end
+  end)
+  if not stat then log('Socket receive error: '..err) end
 
-  -- Receive commands from C-Bus and publish to MQTT
-    cmd = server:receive()
-    if cmd then
-        parts = string.split(cmd, "/")
-        zigbee_address = parts[1]
-        level = tonumber(parts[2])
-        ramp = tonumber(parts[3]) -- Ignoring ramp for now
-        state = (level ~= 0) and "ON" or "OFF"
-        client:publish(mqtt_topic .. "/" .. zigbee_address .. "/set", '{"state":"'..state..
-            '","brightness":"'..level..'"}', 2, true) -- QoS 2 for send exactly once
+  if mqttStatus == 1 then
+    -- Process MQTT message buffers synchronously - sends and receives
+    client:loop(mqttTimeout)
+
+    if #cbusMessages > 0 then
+      -- Send outstanding messages to MQTT
+      stat, err = pcall(outstandingCbusMessage)
+      if not stat then log('Error processing outstanding CBus messages: '..err) cbusMessages = {} end -- Log error and clear the queue, continue
     end
 
+    if #mqttMessages > 0 then
+      -- Send outstanding messages to CBus
+      stat, err = pcall(outstandingMqttMessage)
+      if not stat then log('Error processing outstanding MQTT messages: '..err) mqttMessages = {} end -- Log error and clear the queue
+    end
+  elseif mqttStatus == 2 or not mqttStatus then
+    -- MQTT is disconnected, so attempt a connection, waiting. If fail to connect then retry.
+    if init then
+      log('Connecting to Mosquitto broker')
+      timeoutStart = socket.gettime()
+      connectStart = timeoutStart
+      init = false
+    end
+    stat, err = pcall(function (b, p, k) client:connect(b, p, k) end, mqttBroker, 1883, 25) -- Requested keep-alive 25 seconds, broker at port 1883
+    if not stat then -- Log and abort
+      log('Error calling connect to broker: '..err)
+      pcall(function () server:close() end)
+      do return end
+    end
+    while mqttStatus ~= 1 do
+      client:loop(1) -- Service the client with a generous timeout
+      if socket.gettime() - connectStart > timeout then
+        if socket.gettime() - timeoutStart > warningTimeout then
+          log('Failed to connect to the Mosquitto broker, retrying continuously')
+          timeoutStart = socket.gettime()
+        end
+        connectStart = socket.gettime()
+        goto next -- Exit to the main loop to keep socket messages monitored
+      end
+    end
+    mqttConnected = socket.gettime()
+    -- Subscribe to relevant topics
+    client:subscribe(mqttTopic..'#', mqttQoS)
+    -- Connected... Now loop briefly to allow retained value retrieval for subscribed topics because synchronous
+    while socket.gettime() - mqttConnected < 0.5 do client:loop(0) end
+    if not reconnect then -- Full publish topics
+      stat, err = pcall(cudZig) if not stat then log(err) log('Halting') while true do socket.select(nil, nil, 1) end end
+      stat, err = pcall(publishCurrent) if not stat then log('Error publishing current values: '..err) end -- Log and continue
+    end
+  else
+    log('Error: Invalid mqttStatus: '..mqttStatus)
+    pcall(function () server:close() end)
+    do return end
+  end
+
+  local t = socket.gettime()
+  if checkChanges and t > changesChecked then
+    changesChecked = t
+    stat, err = pcall(cudZig) if not stat then log(err) log('Halting') while true do socket.select(nil, nil, 1) end end
+  end
+
+  ::next::
 end

--- a/zigbee resident.lua
+++ b/zigbee resident.lua
@@ -47,7 +47,7 @@ Check for presence of the event script
 local eventScripts = db:getall("SELECT name FROM scripting WHERE type = 'event'")
 found = false
 for _, s in ipairs(eventScripts) do
-  if s.name:lower() == eventName then found = true eventName = s.name end
+  if s.name:lower() == eventName:lower() then found = true eventName = s.name end
 end
 if not found then
   log('Error: Event-based script \''..eventName..'\' not found. Halting')

--- a/zigbee resident.lua
+++ b/zigbee resident.lua
@@ -10,7 +10,7 @@ mqtt_broker = '192.168.1.1'
 mqtt_username = ''
 mqtt_password = ''
 mqtt_clientid = 'cbus2zigbee'
-eventName = 'zigbee' -- The name of the ZigBee event script
+eventName = 'zigbee' -- The name of the Zigbee event script
 local checkChanges = nil -- Interval in seconds to check for changes to object keywords (set to nil to disable change checks, recommended once configuration is stable)
 local lighting = { ['56'] = true, } -- Array of applications that are used for lighting
 
@@ -185,7 +185,7 @@ local function cudZig()
         
         zigbee[alias] = { name=v.name, address=_L.z, net=v.net, app=v.app, group=v.group, keywords=curr, }
       else
-        log('Error: Invalid or no z= hexadecimal address specified for ZigBee object '..alias)
+        log('Error: Invalid or no z= hexadecimal address specified for Zigbee object '..alias)
         zigbee[alias] = { name=v.name, net=v.net, app=v.app, group=v.group, keywords=curr, } 
       end
       zigbeeFriendly[_L.z] = { alias=alias, net=v.net, app=v.app, group=v.group, }
@@ -195,16 +195,16 @@ local function cudZig()
   -- Handle deletions
   for k, v in pairs(zigbee) do
     if not found[k] then
-      log('Removing '..k..' ZigBee '..v.name) zigbeeFriendly[k.address] = nil zigbee[k] = nil remCount = remCount + 1
+      log('Removing '..k..' Zigbee '..v.name) zigbeeFriendly[k.address] = nil zigbee[k] = nil remCount = remCount + 1
     end
   end
   if remCount > 0 then
-    log('Removed '..remCount..' ZigBee object'..(remCount ~= 1 and 's' or '')..', event script \''..eventName..'\' restarted')
+    log('Removed '..remCount..' Zigbee object'..(remCount ~= 1 and 's' or '')..', event script \''..eventName..'\' restarted')
   end
   -- Handle additions/modifications
   if addition or modification then
-    if addition then log('Added '..addCount..' ZigBee object'..(addCount ~= 1 and 's' or '')..(addCount > 0 and ', event script \''..eventName..'\' restarted' or '')) end
-    if modification then log('Modified '..modCount..' ZigBee object'..(modCount ~= 1 and 's' or '')..(modCount > 0 and ', event script \''..eventName..'\' restarted' or '')) end
+    if addition then log('Added '..addCount..' Zigbee object'..(addCount ~= 1 and 's' or '')..(addCount > 0 and ', event script \''..eventName..'\' restarted' or '')) end
+    if modification then log('Modified '..modCount..' Zigbee object'..(modCount ~= 1 and 's' or '')..(modCount > 0 and ', event script \''..eventName..'\' restarted' or '')) end
   end
   if addCount > 0 or modCount > 0 or remCount > 0 then
     script.disable(eventName) script.enable(eventName) -- Ensure that newly changed keyworded groups send updates


### PR DESCRIPTION
Hey Geoff.

This pull request adds many things, but not least of all the foundation for bidirectional C-Bus/ZigBee via zigbee2mqtt.

It adds:
- Create/update/delete for ZIGBEE keyword settings, probably in an overkill way, but in a way that is highly extensible for adding new keywords. Think things like sensor value scale (scale=), or number of decimal places (dec=) for user parameter values.
- Synchronous Mosquitto broker comms, avoiding loop_start to allow re-entry to script on error conditions that force an exit, handling socket:close before reopen on reentry as well.
- Message queueing for inbound and outbound.
- Mosquitto broker re-connection, with queueing of C-Bus level/status changes while the broker is out of action. Once re-connected all C-Bus messages will be sent to the broker in order.
- Shifting the responsibility of keyword monitoring from event-based to resident (on check changes, which can be disabled). Plus adding validation of the hexidecimal ZigBee unique ID.

Using a ZigBee 'friendly' name if set is not yet considered.

I'm still waiting for a ZigBee interface to arrive, which has been stuck on Long Island NY for a while. Given a looming Easter I will probably give up all hope before it gets here. This is why I have not evolved sending to C-Bus from the broker subscriptions, as I'm running blind. But I thought I'd share where my head is going with all this.