### PR TITLE
Add sensors and fix some issues

### DIFF
--- a/zigbee event.lua
+++ b/zigbee event.lua
@@ -11,7 +11,11 @@ Add a "z=<zigbee address from zigbee2mqtt" to the keyword as well
 local logging = true
 local zPort = 0xBEEF1
 local parts = string.split(event.dst, '/') local net = tonumber(parts[1]) local app = tonumber(parts[2]) local group = tonumber(parts[3])
-ramp = GetCBusRampRate(net, app, group)
+if app ~= 228 and app ~= 250 then
+  ramp = GetCBusRampRate(net, app, group)
+else
+  ramp = 0
+end
 
 -- Send an event to zigbee2mqtt
 local output = event.dst.."/"..event.getvalue().."/"..ramp

--- a/zigbee resident.lua
+++ b/zigbee resident.lua
@@ -463,7 +463,7 @@ while true do
     -- Subscribe to relevant topics
     client:subscribe(mqttTopic..'bridge/#', mqttQoS)
     -- Connected... Now loop briefly to allow retained value retrieval for subscribed topics because synchronous
-    while socket.gettime() - mqttConnected < 1 do
+    while socket.gettime() - mqttConnected < 0.5 do
       client:loop(0)
       if #mqttMessages > 0 then
         -- Send outstanding messages to CBus
@@ -474,6 +474,12 @@ while true do
     if not reconnect then -- Full publish topics
       stat, err = pcall(cudZig) if not stat then log('Error in cudZig(): '..err) end
       stat, err = pcall(publishCurrent) if not stat then log('Error publishing current values: '..err) end -- Log and continue
+    else -- Resubscribe
+      local address
+      for address, _ in pairs(subscribed) do
+        ignoreMqtt[zigbeeAddress[address]] = true
+        client:subscribe(mqttTopic..address, mqttQoS)
+      end
     end
   else
     log('Error: Invalid mqttStatus: '..mqttStatus)


### PR DESCRIPTION
This is an early attempt at zigbee sensors, Geoff.

The script now looks up the 'exposes' value of zigbee devices, and then allows sensor= keywords to match. More than one C-Bus object is possible for each zigbee address. Examples:

- ZIGBEE, z=0x00169a00022256da, sensor=temperature, 
- ZIGBEE, z=0x00169a00022256da, sensor=humidity, 

The lighting and user parameter applications are implemented for receipt of sensor values.

Given I'm still flying blind without a coordinator, feedback about whether it actually works with devices would be most welcome. I've been using 'static' topics to describe my test devices, which probably falls short compared to a live environment.

Lighting updates from the Mosquitto broker should also flow back into C-Bus.