### PR TITLE
Attempt to solve race condition affecting ignoreCbus #10

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Add the following:
 * light, to indicate a lighting object (the default type, so optional to specify for lights)
 * switch, to indicate a switching object
 * sensor, to indicate a sensor object
-* exposed=exposes_name, to tie a C-Bus object to an exposed Zigbee value (not used for light)
+* exposed=exposes_name, to tie a C-Bus object to an exposed Zigbee value (not used for light, exposes= is an alias)
 * type=number|boolean, to specify the data type (sensor only, "number" is the default)
 * parameter=altparameter, to specify an alternate for a 'parameter' value in the 'exposes' value of a Zigbee object (the default is "parameter", not used for light)
 
@@ -49,7 +49,7 @@ Add the following:
 * ZIGBEE, light, z=0xa4c1389bf2e3ae5f, 
 * ZIGBEE, light, name=office/office desk strip, 
 * ZIGBEE, sensor, addr=0x00169a00022256da, exposed=humidity, 
-* ZIGBEE, switch, name=3way, exposed=state_l1, 
+* ZIGBEE, switch, name=3way, exposes=state_l1, 
 
 ## Contributing
 

--- a/zigbee resident.lua
+++ b/zigbee resident.lua
@@ -626,9 +626,6 @@ while true do
       stat, err = pcall(cudZig) if not stat then log('Error in cudZig(): '..err) end
     end
 
-    -- Process MQTT message buffers synchronously - sends and receives
-    client:loop(mqttTimeout)
-
     if #cbusMessages > 0 then
       -- Send outstanding messages to MQTT
       stat, err = pcall(outstandingCbusMessage)
@@ -638,6 +635,9 @@ while true do
         log(#cbusMessages..' outstanding message'..(#cbusMessages > 1 and 's' or '')..', device(s) are offline')
       end
     end
+
+    -- Process MQTT message buffers synchronously - sends and receives
+    client:loop(mqttTimeout)
 
     if #mqttMessages > 0 then
       -- Send outstanding messages to CBus

--- a/zigbee resident.lua
+++ b/zigbee resident.lua
@@ -647,7 +647,7 @@ while true do
 
     for alias, ignore in pairs(ignoreCbus) do
       if socket.gettime() - ignore.time > ignoreTimeout then
-        if logging then log('Warning: Removed orphaned C-Bus ignore flag for '..alias..', the expected level '..ignoreCbus[alias]..' was never received') end
+        if logging then log('Warning: Removed orphaned C-Bus ignore flag for '..alias..', the expected level '..ignoreCbus[alias].expecting..' was never received') end
         ignoreCbus[alias] = nil
       end
     end

--- a/zigbee resident.lua
+++ b/zigbee resident.lua
@@ -504,7 +504,6 @@ local function statusUpdate(alias, friendly, payload)
           if logging then log('Set '..z.alias..', '..z.expose..'='..value) end
           ignoreCbus[z.alias] = { expecting=value, time=socket.gettime(), was=grp.getvalue(z.alias), }
           grp.write(z.alias, value)
-          zigbee[z.alias].value = value
         end
       else
         log('Error: Nil value for switch '..z.alias)
@@ -523,7 +522,6 @@ local function statusUpdate(alias, friendly, payload)
           else
             grp.write(z.alias, value)
           end
-          zigbee[z.alias].value = value
         end
       else
         log('Error: Nil value for sensor '..z.alias)
@@ -542,14 +540,12 @@ local function statusUpdate(alias, friendly, payload)
           if logging then log('Set '..z.alias..' to '..value) end
           ignoreCbus[z.alias] = { expecting=value, time=socket.gettime(), was=grp.getvalue(z.alias), }
           grp.write(z.alias, value)
-          zigbee[z.alias].value = value
         end
       else
         if grp.getvalue(z.alias) ~= 0 then
           if logging then log('Set '..z.alias..' to OFF') end
-          ignoreCbus[z.alias] = { expecting=value, time=socket.gettime(), was=grp.getvalue(z.alias), }
+          ignoreCbus[z.alias] = { expecting=0, time=socket.gettime(), was=grp.getvalue(z.alias), }
           grp.write(z.alias, 0)
-          zigbee[z.alias].value = 0
         end
       end
     end

--- a/zigbee resident.lua
+++ b/zigbee resident.lua
@@ -259,16 +259,16 @@ local function cudZig()
       end
       
       local function configureReporting(friendly)
+        if logging then log('Configure reporting for '..alias..' '..friendly) end
+        local msg
         local config = 'bridge/request/device/configure_reporting'
-        local msg = {
-          id = friendly,
-          cluster = 'genLevelCtrl',
-          attribute = 'currentLevel',
-          minimum_report_interval = 0,
-          maximum_report_interval = 3600,
-          reportable_change = 1,
-        }
-        if logging then log('Configure reporting for '..alias..' '..friendly..', '..json.encode(msg)) end
+        msg = { id = friendly, cluster='genLevelCtrl', attribute='currentLevel', minimum_report_interval=0, maximum_report_interval=3600, reportable_change=0, }
+        client:publish(mqttTopic..config, json.encode(msg), QoS, false)
+        msg = { id = friendly, cluster='genOnOff', attribute = 'onOff', minimum_report_interval=0, maximum_report_interval=3600, reportable_change=0, }
+        client:publish(mqttTopic..config, json.encode(msg), QoS, false)
+        msg = { id = friendly, cluster='lightingColorCtrl', attribute = 'currentX', minimum_report_interval=0, maximum_report_interval=3600, reportable_change=0, }
+        client:publish(mqttTopic..config, json.encode(msg), QoS, false)
+        msg = { id = friendly, cluster='lightingColorCtrl', attribute = 'currentY', minimum_report_interval=0, maximum_report_interval=3600, reportable_change=0, }
         client:publish(mqttTopic..config, json.encode(msg), QoS, false)
       end
 

--- a/zigbee resident.lua
+++ b/zigbee resident.lua
@@ -108,7 +108,7 @@ local function eventCallback(event)
   if lighting[parts[2]] then
     value = tonumber(string.sub(event.datahex,1,2),16)
     local target = tonumber(string.sub(event.datahex,3,4),16)
-    if event.meta == 'admin' then -- A ramp always begins with an admin message, so queue a transition, but only if ramping (other simple non-ramp messages are seen as admin as well)
+    if event.meta == 'admin' or event.sender ~= 'cb' then -- A ramp always begins with an admin or non-C-Bus message (like a scene, so queue a transition, but only if ramping (other simple non-ramp messages are seen as admin as well)
       if ramp > 0 then
         cbusMessages[#cbusMessages + 1] = { alias=event.dst, level=target, origin=origin, ramp=ramp, } -- Queue the event
         return


### PR DESCRIPTION
@geoffwatts, give the code in this draft pull a try in a test resident to see if it avoids race.

The first thing I've added is a timeout for ignoreCbus flags. If your suspected race condition is really setting ignoreCbus and then it never gets cleared, then this draft will kill the ignore flag after 0.5 seconds and log the event.

There is a potential for race condition, though. The main loop does eventbus step() then MQTT loop(), then it processes queued C-Bus messages first, and then immediately after it processes the MQTT messages. A MQTT change that affected the same GA could mess things up.

So the second thing I have changed is this sequence to step(), process C-Bus, loop(), process MQTT.